### PR TITLE
Add TinyTools AI Cost Calculator to Cost calculators and dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The community maintained data sources that the rest of the ecosystem depends on.
 - [PricePerToken](https://pricepertoken.com) - Comparison and leaderboards across 300+ models.
 - [TokenCost App](https://tokencost.app) - Leaderboard with quality versus cost scoring.
 - [CostGoat](https://costgoat.com) - Closed source. Desktop app for tracking OpenRouter and multi provider spend in real time.
+- [TinyTools AI Cost Calculator](https://tinytools-smoky.vercel.app/) - Free browser side calculator for estimating spend across Claude, GPT, and Gemini models. Plug in expected input and output tokens, request volume, and cache hit rate to compare per million token cost across providers. No signup, all calculation runs in the browser.
 
 ## Cost Aware Serving Research
 


### PR DESCRIPTION
Adds **[TinyTools AI Cost Calculator](https://tinytools-smoky.vercel.app/)** under "Cost calculators and dashboards".

**What it is:** A free, browser-based AI cost calculator for estimating LLM spend across providers. Inputs: expected input tokens, output tokens, request volume, and cache-hit rate. Outputs: per-million-token cost and total spend across Claude, GPT, and Gemini models — useful for back-of-envelope budgeting before committing to a provider.

Sits alongside [PricePerToken](https://pricepertoken.com) and [TokenCost App](https://tokencost.app) in that section.

- No signup, no account
- All calculation runs in the browser
- Open source

Live: https://tinytools-smoky.vercel.app/

For context, TinyTools is a small collection of single-purpose web utilities; the AI cost calculator is the relevant one for this list.