### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Tools that show you where your tokens go and let you set limits before the bill 
 
 ### Open source
 
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first TUI and CLI that turns AI coding agent trace logs into cost, token, latency, and health regression reports.
 - [Langfuse](https://github.com/langfuse/langfuse) - Full LLM tracing, prompt management, evaluation, datasets, with token and cost tracking exposed via a metrics API. Self hostable on PostgreSQL and ClickHouse.
 - [Helicone](https://github.com/Helicone/helicone) - Proxy first observability with cost tracking, caching, and rate limits, no SDK install required. Self hostable.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - OpenTelemetry instrumentation for LLMs from Traceloop. Vendor neutral, exports to any OTel backend.


### PR DESCRIPTION
## What this PR adds

Adds agenttrace to Cost Tracking, Observability, and Budgets.

## Checklist

- [x] Entry follows the format documented in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Project is actively maintained (last meaningful update within 12 months)
- [x] One line description is accurate and not marketing copy
- [x] Entry is in the correct category, alphabetically placed
- [x] Only one entry added in this PR (one entry per PR makes review tractable)

## Context

agenttrace turns local AI coding agent trace logs into cost, token, latency, and health regression reports. It fits the cost tracking category because it helps teams see where coding-agent tokens and spend go, then gate regressions in CI.

Disclosure: I maintain agenttrace.

## Checks

- git diff --check
- npx awesome-lint (local clone reports "Awesome list must reside in a valid git repository" outside PR CI context)