### PR TITLE
Add tokenalyzer to Cost Tracking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Tools that show you where your tokens go and let you set limits before the bill 
 ### Open source
 
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first TUI and CLI that turns AI coding agent trace logs into cost, token, latency, and health regression reports.
+- [tokenalyzer](https://github.com/shyh26/tokenalyzer) - Analyzes Claude Code session logs to show token usage and costs, broken down by project, session, and model.
 - [Langfuse](https://github.com/langfuse/langfuse) - Full LLM tracing, prompt management, evaluation, datasets, with token and cost tracking exposed via a metrics API. Self hostable on PostgreSQL and ClickHouse.
 - [Helicone](https://github.com/Helicone/helicone) - Proxy first observability with cost tracking, caching, and rate limits, no SDK install required. Self hostable.
 - [OpenLLMetry](https://github.com/traceloop/openllmetry) - OpenTelemetry instrumentation for LLMs from Traceloop. Vendor neutral, exports to any OTel backend.


### PR DESCRIPTION
tokenalyzer analyzes Claude Code session logs to show token usage and costs, broken down by project, session, and model.

- Per-project breakdown with input/output/cache read columns
- Session-level drill-down via --detail flag
- Cost estimation for Claude, GPT, and other models
- Zero config - points at ~/.claude and works

GitHub: https://github.com/shyh26/tokenalyzer

One-time $9, MIT licensed.