### PR TITLE
Add FerryAPI to gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Sit between your app and providers. Pick the right model for each request based 
 - [TrueFoundry AI Gateway](https://www.truefoundry.com) - Closed source. Enterprise gateway with RBAC, virtual models, and deployment flexibility.
 - [Kong AI Gateway](https://konghq.com/products/kong-ai-gateway) - Closed source. Kong's AI plugins for teams already running Kong as their API layer.
 - [Bifrost](https://github.com/maximhq/bifrost) - Rust based router with microsecond scale overhead at high RPS, plus built in budget controls and intelligent routing.
+- [FerryAPI](https://www.ferryapi.io/) - Closed source. OpenAI compatible gateway with prepaid billing, customer API keys, and usage records.
 
 ### Smart and cost aware routers
 


### PR DESCRIPTION
## What this PR adds

Adds FerryAPI to the Gateways and proxies section.

## Checklist

- [x] Entry follows the format documented in CONTRIBUTING.md
- [x] Project is actively maintained (public docs/site available and product is live)
- [x] One line description is accurate and not marketing copy
- [x] Entry is in the correct category
- [x] Only one entry added in this PR

## Context

FerryAPI is a closed-source OpenAI-compatible gateway. It fits this section because it sits between applications and model providers, with prepaid billing, customer API keys, and usage records that can help teams control LLM spend.

Disclosure: I am doing growth/distribution work for FerryAPI, so please apply extra scrutiny and feel free to reject if it does not meet the list's quality bar.